### PR TITLE
supertubes-cli: fix url

### DIFF
--- a/Formula/supertubes-cli.rb
+++ b/Formula/supertubes-cli.rb
@@ -5,10 +5,10 @@ class SupertubesCli < Formula
   version "0.5.0"
 
   if OS.mac?
-    url "https://banzaicloud.com/downloads/supertubes-cli/v0.5.0/dist/supertubes_0.5.0_darwin_amd64.tar.gz"
+    url "https://banzaicloud.com/downloads/supertubes-cli/0.5.0/dist/supertubes_0.5.0_darwin_amd64.tar.gz"
     sha256 "a3a6a3ee9a46eebbaf9c5cb5def1e56e1ffd502c99f39d6560ef17a8dc7ecf08"
   elsif OS.linux?
-    url "https://banzaicloud.com/downloads/supertubes-cli/v0.5.0/dist/supertubes_0.5.0_linux_amd64.tar.gz"
+    url "https://banzaicloud.com/downloads/supertubes-cli/0.5.0/dist/supertubes_0.5.0_linux_amd64.tar.gz"
     sha256 "37b41eb9c7eff5ac72b86c54da5635989fd1aac1e93123d3aecfee6fa67bd25d"
   end
 


### PR DESCRIPTION
fixes
```
curl: (22) The requested URL returned error: 403
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "supertubes-cli"
Download failed: https://banzaicloud.com/downloads/supertubes-cli/v0.5.0/dist/supertubes_0.5.0_darwin_amd64.tar.gz
```