### PR TITLE
Revert "Brew formula update for backyards version v1.4.8"

### DIFF
--- a/Formula/backyards-cli.rb
+++ b/Formula/backyards-cli.rb
@@ -2,16 +2,16 @@
 class BackyardsCli < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
-  version "1.4.8"
+  version "1.5.0"
   bottle :unneeded
 
   if OS.mac?
-    url "https://banzaicloud.com/downloads/backyards-cli/1.4.8/dist/backyards_1.4.8_darwin_amd64.tar.gz"
-    sha256 "994081bb170a02f0dfe7c257edb8e7561cab8adb5c757845d5b3a59ff7773083"
+    url "https://banzaicloud.com/downloads/backyards-cli/1.5.0/dist/backyards_1.5.0_darwin_amd64.tar.gz"
+    sha256 "79ce3386adce21bcebc09565a915ad09d713181df2488232eff76264bfa09738"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://banzaicloud.com/downloads/backyards-cli/1.4.8/dist/backyards_1.4.8_linux_amd64.tar.gz"
-      sha256 "f1a2d3390ca2c363a354bf5e5e8ff84fd6d8d58528874c8e84f52b8254bb7e2e"
+      url "https://banzaicloud.com/downloads/backyards-cli/1.5.0/dist/backyards_1.5.0_linux_amd64.tar.gz"
+      sha256 "eb5bccaa88762665896b70d5f6d1e3a6c25fb89626d942896abe2dcbd4d6d438"
     end
   end
 


### PR DESCRIPTION
This reverts commit 82901e8d420c6cf811d976ed49e92a1cf085ea8b.

For brew we should still have the 1.5.0 release available as the 1.4.8 is just a fix release.
