### PR TITLE
Fixed formulae by removing disabled `bottle :unneeded` refs

### DIFF
--- a/Formula/backyards-cli.rb
+++ b/Formula/backyards-cli.rb
@@ -3,7 +3,6 @@ class BackyardsCli < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.5"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.5/dist/backyards_1.5.5_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.4.10.rb
+++ b/Formula/backyards-cli@1.4.10.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT1410 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.4.10"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.4.10/dist/backyards_1.4.10_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.4.11.rb
+++ b/Formula/backyards-cli@1.4.11.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT1411 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.4.11"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.4.11/dist/backyards_1.4.11_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.4.8.rb
+++ b/Formula/backyards-cli@1.4.8.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT148 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.4.8"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.4.8/dist/backyards_1.4.8_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.4.9.rb
+++ b/Formula/backyards-cli@1.4.9.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT149 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.4.9"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.4.9/dist/backyards_1.4.9_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.5.0.rb
+++ b/Formula/backyards-cli@1.5.0.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT150 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.0/dist/backyards_1.5.0_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.5.1.rb
+++ b/Formula/backyards-cli@1.5.1.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT151 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.1/dist/backyards_1.5.1_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.5.2.rb
+++ b/Formula/backyards-cli@1.5.2.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT152 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.2/dist/backyards_1.5.2_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.5.3.rb
+++ b/Formula/backyards-cli@1.5.3.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT153 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.3/dist/backyards_1.5.3_darwin_amd64.tar.gz"

--- a/Formula/backyards-cli@1.5.4.rb
+++ b/Formula/backyards-cli@1.5.4.rb
@@ -3,7 +3,6 @@ class BackyardsCliAT154 < Formula
   desc "Command-line interface for Backyards"
   homepage "https://banzaicloud.com/"
   version "1.5.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/backyards-cli/1.5.4/dist/backyards_1.5.4_darwin_amd64.tar.gz"

--- a/Formula/bank-vaults.rb
+++ b/Formula/bank-vaults.rb
@@ -6,7 +6,6 @@ class BankVaults < Formula
   desc "A Vault swiss-army knife CLI with Kubernetes support"
   homepage "https://banzaicloud.com/products/bank-vaults/"
   version "1.14.3"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/one-eye.rb
+++ b/Formula/one-eye.rb
@@ -3,7 +3,6 @@ class OneEye < Formula
   desc "Command-line interface for One Eye"
   homepage "https://banzaicloud.com/"
   version "0.4.5"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/one-eye/0.4.5/dist/one-eye_0.4.5_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli.rb
+++ b/Formula/supertubes-cli.rb
@@ -3,7 +3,6 @@ class SupertubesCli < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "1.1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/1.1.0/dist/supertubes_1.1.0_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.5.5.rb
+++ b/Formula/supertubes-cli@0.5.5.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT055 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.5.5"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.5.5/dist/supertubes_0.5.5_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.6.0.rb
+++ b/Formula/supertubes-cli@0.6.0.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT060 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.6.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.6.0/dist/supertubes_0.6.0_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.6.1.rb
+++ b/Formula/supertubes-cli@0.6.1.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT061 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.6.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.6.1/dist/supertubes_0.6.1_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.6.2.rb
+++ b/Formula/supertubes-cli@0.6.2.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT062 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.6.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.6.2/dist/supertubes_0.6.2_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.7.0.rb
+++ b/Formula/supertubes-cli@0.7.0.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT070 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.7.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.7.0/dist/supertubes_0.7.0_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@0.7.1.rb
+++ b/Formula/supertubes-cli@0.7.1.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT071 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "0.7.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/0.7.1/dist/supertubes_0.7.1_darwin_amd64.tar.gz"

--- a/Formula/supertubes-cli@1.0.0.rb
+++ b/Formula/supertubes-cli@1.0.0.rb
@@ -3,7 +3,6 @@ class SupertubesCliAT100 < Formula
   desc "Command-line interface for Supertubes"
   homepage "https://banzaicloud.com/"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://banzaicloud.com/downloads/supertubes-cli/1.0.0/dist/supertubes_1.0.0_darwin_amd64.tar.gz"

--- a/Formula/terraform-provider-k8s.rb
+++ b/Formula/terraform-provider-k8s.rb
@@ -6,7 +6,6 @@ class TerraformProviderK8s < Formula
   desc "Kubernetes Terraform provider with support for raw manifests"
   homepage "https://banzaicloud.com/"
   version "0.9.1"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/banzaicloud/terraform-provider-k8s/releases/download/v0.9.1/terraform-provider-k8s_0.9.1_darwin_amd64.zip"

--- a/Formula/terraform-provider-yami.rb
+++ b/Formula/terraform-provider-yami.rb
@@ -3,7 +3,6 @@ class TerraformProviderYami < Formula
   desc "Terraform provider with YAML deep merge capabilities"
   homepage "https://banzaicloud.com/"
   version "0.0.5"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/banzaicloud/terraform-provider-yami/releases/download/0.0.5/terraform-provider-yami_0.0.5_darwin_amd64.tar.gz"

--- a/Formula/yami.rb
+++ b/Formula/yami.rb
@@ -3,7 +3,6 @@ class Yami < Formula
   desc "YAML CLI merge tool"
   homepage "https://banzaicloud.com/"
   version "0.0.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/banzaicloud/yami/releases/download/0.0.4/yami_0.0.4_darwin_amd64.tar.gz"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed formulae by removing disabled `bottle :unneeded` refs.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

`Bottle :unneeded` command was disabled and broke the brew install flow (it is not necessary or used anymore).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- [Bottle :unneeded meaning](https://stackoverflow.com/questions/45132704/what-does-bottle-unneeded-do)
- [Example of the issue and fix](https://github.com/c-bata/kube-prompt/issues/88).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
